### PR TITLE
Feat: Issue#35 view user additional information

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,1 @@
 export const BASE_API = process.env.REACT_APP_BASE_API ?  process.env.REACT_APP_BASE_API : "http://localhost:5000"
-// export const BASE_API = process.env.REACT_APP_BASE_API ?  process.env.REACT_APP_BASE_API : "https://bridgeintech-bit-heroku-psql.herokuapp.com"

--- a/src/myspace/AdditionalInfo.jsx
+++ b/src/myspace/AdditionalInfo.jsx
@@ -1,21 +1,149 @@
-import React from "react";
+import React, { useState, useEffect, useContext } from "react";
+import { BASE_API } from "../config";
+import { AuthContext } from "../AuthContext";
+import "./MySpace.css";
+
 
 export default function AdditionalInfo() {
-    return (
-        <div className="container-fluid" id="profile">
-          <div className="top">
-            <h1>
-              This is the Private page for Member's Additional Info page
-            </h1>
-          </div>
-          <div className="middle">
-            <h2>The site is currently under construction...</h2>
-          </div>
-          <div className="bottom">
-            <h3>
-                Thank you for your patience and understanding.
-            </h3>
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [additionalInfo, setAdditionalInfo] = useState({});
+  const { access_token, user } = useContext(AuthContext);
+
+  const requestAdditionalInfo = {
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${access_token}`,
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+    },
+  };
+
+
+  let data = "";
+  useEffect(() => {
+    fetch(`${BASE_API}/user/additional_info`, requestAdditionalInfo)
+      .then(async response => {
+        data = await response.json();
+        if (response.ok) {
+          setAdditionalInfo(data);
+        } else {
+          throw new Error(data);
+        }
+      })
+      .catch(error => {
+        setErrorMessage(data.message);
+      });
+
+  });
+
+  return errorMessage ?
+    <div className="container-fluid" id="additionalInfo">
+      <div className="top">
+        <h1>
+          {errorMessage}
+        </h1>
+      </div>
+    </div>
+    :
+    <>
+      <div className="container" id="additionalInfo">
+        <div className="row mb-5">
+          <div className="col-lg-12 text-center">
+            <h1 className="mt-5">Additional Info</h1>
           </div>
         </div>
-    )
+        <div className="row">
+          <div className="col-lg-12">
+            <form className="myspace-form mx-auto">
+              <form-group controlId="formUserame">
+                <p className="input-control">
+                  <label htmlFor="username">Username :</label>
+                  <input className="field"
+                    type="text"
+                    name="username"
+                    placeholder={user}
+                    disabled
+                  />
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formPhone">
+                <p className="input-control">
+                  <label htmlFor="phone">Phone :</label>
+                  <input className="field"
+                    type="text"
+                    name="phone"
+                    placeholder={additionalInfo.phone}
+                    disabled
+                  />
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formMobile">
+                <p className="input-control">
+                  <label htmlFor="mobile">Mobile :</label>
+                  <input className="field"
+                    type="text"
+                    name="mobile"
+                    placeholder={additionalInfo.mobile}
+                    disabled
+                  />
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formPersonalWebsite">
+                <p className="input-control">
+                  <label htmlFor="personalWebsite">Personal Website :</label>
+                  <input className="field"
+                    type="text"
+                    name="personalWebsite"
+                    placeholder={additionalInfo.personal_website}
+                    disabled
+                  />
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formTimezone">
+                <p className="input-control">
+                  <label htmlFor="timezone">Timezone :</label>
+                  <input className="field"
+                    type="text"
+                    name="timezone"
+                    placeholder={additionalInfo.timezone}
+                    disabled
+                  />
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formIsOrganizationRepCheck">
+                <div className="row">
+                  <div className="col-sm">
+                    <p className="input-control">
+                      <input
+                        type="checkbox"
+                        name="isOrganizationRep"
+                        aria-label="isOrganizationRep"
+                        defaultChecked={additionalInfo.is_organization_rep}
+                        disabled
+                      />
+                    </p>
+                  </div>
+                  <div className="col-sm-11">
+                    {additionalInfo.is_organization_rep ?
+                      <label>
+                        You have declared that you are an organization representative
+                      </label>
+                      :
+                      <label>
+                        You have declared that you do not represent an organization
+                      </label>
+                    }
+                  </div>
+                </div>
+              </form-group>
+            </form>
+          </div>
+        </div>
+      </div>
+    </>
 }

--- a/src/myspace/AdditionalInfo.jsx
+++ b/src/myspace/AdditionalInfo.jsx
@@ -19,21 +19,18 @@ export default function AdditionalInfo() {
   };
 
 
-  let data = "";
   useEffect(() => {
     fetch(`${BASE_API}/user/additional_info`, requestAdditionalInfo)
       .then(async response => {
-        data = await response.json();
+        const data = await response.json();
         if (response.ok) {
-          setAdditionalInfo(data);
-        } else {
-          throw new Error(data);
+          return setAdditionalInfo(data);
         }
-      })
-      .catch(error => {
         setErrorMessage(data.message);
-      });
-
+      })
+      .catch(error => 
+        setErrorMessage("The service is temporarily unavailable, please try again later.")
+      )
   });
 
   return errorMessage ?

--- a/src/myspace/PersonalDetails.jsx
+++ b/src/myspace/PersonalDetails.jsx
@@ -8,7 +8,7 @@ export default function PersonalDetails() {
   const [errorMessage, setErrorMessage] = useState(null);
   const [personalDetails, setPersonalDetails] = useState({});
   const { access_token } = useContext(AuthContext);
-  
+
   const requestPersonalDetails = {
     method: "GET",
     headers: {
@@ -21,24 +21,31 @@ export default function PersonalDetails() {
   let data = "";
   useEffect(() => {
     fetch(`${BASE_API}/user/personal_details`, requestPersonalDetails)
-    .then(async response => {
-
-      data = await response.json();
-      setPersonalDetails(data);
-    })
-    .catch(error => {
-      setErrorMessage(data["message"]);
-    });
+      .then(async response => {
+        data = await response.json();
+        if (response.ok) {
+          return setPersonalDetails(data);
+        } else {
+          throw new Error(data.message);
+        }
+      })
+      .catch(error => {
+        setErrorMessage(data.message);
+      });
 
   });
-  
+
   return errorMessage ?
-    <div>
-      <p>{errorMessage}</p>
+    <div className="container-fluid" id="personalDetails">
+      <div className="top">
+        <h1>
+          {errorMessage}
+        </h1>
+      </div>
     </div>
     :
     <>
-      <div className="container" id="personal_details">
+      <div className="container" id="personalDetails">
         <div className="row mb-5">
           <div className="col-lg-12 text-center">
             <h1 className="mt-5">Personal Details</h1>
@@ -105,7 +112,7 @@ export default function PersonalDetails() {
                           <div className="row">
                             <div className="col-sm">
                               <input
-                                name="available_to_mentor"
+                                name="mentor"
                                 aria-label="mentor"
                                 type={type}
                                 defaultChecked={personalDetails.available_to_mentor}
@@ -116,7 +123,7 @@ export default function PersonalDetails() {
                             </div>
                             <div className="col-sm">
                               <input
-                                name="need_mentoring"
+                                name="mentee"
                                 aria-label="mentee"
                                 type={type}
                                 defaultChecked={personalDetails.need_mentoring}
@@ -185,7 +192,7 @@ export default function PersonalDetails() {
                   <label htmlFor="currentOrganization">Current Organization :</label>
                   <input className="field"
                     type="text"
-                    name="current_organization"
+                    name="currentOrganization"
                     placeholder={personalDetails.current_organization}
                     disabled
                   />

--- a/src/tests/Login.test.jsx
+++ b/src/tests/Login.test.jsx
@@ -4,7 +4,6 @@ import { setupServer } from 'msw/node';
 import { render, fireEvent, screen, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Login from "../login/Login";
-import { AuthConsumer, AuthContext } from "../AuthContext";
 import { act } from 'react-dom/test-utils';
 import { BASE_API } from "../config";
 


### PR DESCRIPTION
### Description
Allow user to view their additional infomation page

Fixes #35 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
By login with as a user and geet additional information page by following the path:
 `My Space` -> `Profile` -> on `Personal Details` page hit `Continue` button and see below screenshots:
* if user is a representative of an organization:
![Screen Shot 2020-07-17 at 3 48 04 pm](https://user-images.githubusercontent.com/29667122/87753617-548cc900-c846-11ea-8cda-d230a885e36f.png)

* if user is not a repreesentative of an organization:
![Screen Shot 2020-07-17 at 3 48 48 pm](https://user-images.githubusercontent.com/29667122/87753638-62424e80-c846-11ea-97dc-8dec1820b71c.png)

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] New and existing unit tests pass locally with my changes

**Additional Note**
This is a WIP. Still need to add tests and fix bugs