### PR TITLE
Feat: Update user personal details

### DIFF
--- a/src/Messages.jsx
+++ b/src/Messages.jsx
@@ -1,0 +1,1 @@
+export const SERVICE_ERROR = "The server is currently unavailable. Try again later"; 

--- a/src/login/Login.jsx
+++ b/src/login/Login.jsx
@@ -3,6 +3,7 @@ import "./Login.css";
 import { Redirect } from "react-router-dom";
 import { AuthContext } from "../AuthContext";
 import {BASE_API} from "../config";
+import { SERVICE_ERROR } from "../Messages";
 
 export default function Login() {
     const [errorMessage, setErrorMessage] = useState(null);
@@ -28,12 +29,11 @@ export default function Login() {
         fetch(`${BASE_API}/login`, requestLogin)
             .then(async response => {
                 let data = await response.json();
-                if (response.status === 200) {
-                    login(data, user);
-                }
-                setErrorMessage(data["message"]);
+                if (response.ok) 
+                    return login(data, user);
+                setErrorMessage(data.message);
             })
-            .catch(() => setErrorMessage("The server is currently unavailable. Try again later"));
+            .catch(() => setErrorMessage(SERVICE_ERROR));
     }
 
 

--- a/src/myspace/AdditionalInfo.jsx
+++ b/src/myspace/AdditionalInfo.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from "react";
 import { BASE_API } from "../config";
 import { AuthContext } from "../AuthContext";
 import "./MySpace.css";
+import { SERVICE_ERROR } from "../Messages";
 
 
 export default function AdditionalInfo() {
@@ -23,13 +24,12 @@ export default function AdditionalInfo() {
     fetch(`${BASE_API}/user/additional_info`, requestAdditionalInfo)
       .then(async response => {
         const data = await response.json();
-        if (response.ok) {
+        if (response.ok) 
           return setAdditionalInfo(data);
-        }
         setErrorMessage(data.message);
       })
-      .catch(error => 
-        setErrorMessage("The service is temporarily unavailable, please try again later.")
+      .catch(() => 
+        setErrorMessage(SERVICE_ERROR)
       )
   });
 

--- a/src/myspace/PersonalBackground.jsx
+++ b/src/myspace/PersonalBackground.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from "react";
 import { BASE_API } from "../config";
 import { AuthContext } from "../AuthContext";
 import "./MySpace.css";
+import { SERVICE_ERROR } from "../Messages";
 
 export default function PersonalBackground() {
   const [errorMessage, setErrorMessage] = useState(null);
@@ -21,13 +22,12 @@ export default function PersonalBackground() {
     fetch(`${BASE_API}/user/personal_background`, requestPersonalBackground)
     .then(async response => {
       const data = await response.json();
-      if (response.ok) {
+      if (response.ok) 
         return setPersonalBackground(data);
-      }
       setErrorMessage(data.message);
     })
-    .catch(error => 
-      setErrorMessage("The service is temporarily unavailable, please try again later.")
+    .catch(() => 
+      setErrorMessage(SERVICE_ERROR)
     )
 
   });

--- a/src/myspace/PersonalDetails.jsx
+++ b/src/myspace/PersonalDetails.jsx
@@ -2,12 +2,17 @@ import React, { useState, useEffect, useContext } from "react";
 import { AuthContext } from "../AuthContext";
 import { BASE_API } from "../config";
 import "./MySpace.css";
+import { SERVICE_ERROR } from "../Messages";
 
 
 export default function PersonalDetails() {
   const [errorMessage, setErrorMessage] = useState(null);
+  const [responseMessage, setResponseMessage] = useState(null);
   const [personalDetails, setPersonalDetails] = useState({});
   const { access_token } = useContext(AuthContext);
+  const [isValidName, setIsValidName] = useState(true);
+  const [isValidUsername, setIsValidUsername] = useState(true);
+    
 
   const requestPersonalDetails = {
     method: "GET",
@@ -18,22 +23,67 @@ export default function PersonalDetails() {
     },
   };
 
-  let data = "";
   useEffect(() => {
     fetch(`${BASE_API}/user/personal_details`, requestPersonalDetails)
       .then(async response => {
-        data = await response.json();
-        if (response.ok) {
+        const data = await response.json();
+        if (response.ok) 
           return setPersonalDetails(data);
-        } else {
-          throw new Error(data.message);
-        }
-      })
-      .catch(error => {
         setErrorMessage(data.message);
-      });
+      })
+      .catch(() =>
+        setErrorMessage(SERVICE_ERROR)
+      )
 
   });
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+
+    let payload = {}
+    new FormData(e.target).forEach((value, key) => {
+      if (key === "need_mentoring" || key === "available_to_mentor")
+          if (value === "true")
+              payload[key] = true;
+          else
+              payload[key] = false;
+      else if (key === "email")
+          {}
+      else
+          payload[key] = value;
+    });
+    if (!("available_to_mentor" in payload)) {
+      payload["available_to_mentor"] = false;
+    }
+    if (!("need_mentoring" in payload)) {
+      payload["need_mentoring"] = false;
+    }
+    const requestUpdateDetails = {
+      method: "PUT",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload)
+    };
+    fetch(`${BASE_API}/user/personal_details`, requestUpdateDetails)
+      .then(async response => {
+        let data = await response.json();
+        if (response.ok) {
+          return setResponseMessage(data.message)
+        }
+        setErrorMessage(data.message);
+      })
+      .catch(() => setErrorMessage("The service is temporarily unavailable, please try again later."));
+  }
+
+  const validateName = e => {
+    setIsValidName(e.target.checkValidity());
+  };
+  const validateUsername = e => {
+      setIsValidUsername(e.target.checkValidity());
+  };
 
   return errorMessage ?
     <div className="container-fluid" id="personalDetails">
@@ -53,17 +103,24 @@ export default function PersonalDetails() {
         </div>
         <div className="row">
           <div className="col-lg-12">
-            <form className="myspace-form mx-auto">
+            <form className="myspace-form mx-auto" onSubmit={handleSubmit}>
               <form-group controlId="formUserame">
                 <p className="input-control">
                   <label htmlFor="username">Username :</label>
                   <input className="field"
                     type="text"
                     name="username"
-                    placeholder={personalDetails.username}
-                    disabled
+                    defaultValue={personalDetails.username}
+                    minLength={5}
+                    maxLength={25}
+                    pattern="^[a-zA-Z0-9/_]+$"
+                    onChange={validateUsername}
+                    required
                   />
                 </p>
+                {!isValidUsername && (
+                    <span className="error">Must be between 5-25 characters long. Can only contain alphabets, numbers and underscore '_'</span>
+                )}
               </form-group>
               <div><br></br></div>
               <form-group controlId="formEmail">
@@ -72,7 +129,7 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="email"
-                    placeholder={personalDetails.email}
+                    defaultValue={personalDetails.email}
                     disabled
                   />
                 </p>
@@ -84,10 +141,17 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="name"
-                    placeholder={personalDetails.name}
-                    disabled
+                    defaultValue={personalDetails.name}
+                    minLength={2}
+                    maxLength={30}
+                    pattern="^[a-zA-Z\s\-]+$"
+                    onChange={validateName}
+                    required
                   />
                 </p>
+                {!isValidName && (
+                    <span className="error">Must be between 2-30 characters long. Can only contain alphabets, whitespace and dash '-'</span>
+                )}
               </form-group>
               <div><br></br></div>
               <form-group controlId="formIrcId">
@@ -95,9 +159,19 @@ export default function PersonalDetails() {
                   <label htmlFor="ircId">IRC ID :</label>
                   <input className="field"
                     type="text"
-                    name="ircId"
-                    placeholder={personalDetails.slack_username}
-                    disabled
+                    name="slack_username"
+                    defaultValue={personalDetails.slack_username}
+                  />
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formIrcId">
+                <p className="input-control">
+                  <label htmlFor="socialMediaLink">Social Media Links :</label>
+                  <input className="field"
+                    type="text"
+                    name="social_media_links"
+                    defaultValue={personalDetails.social_media_links}
                   />
                 </p>
               </form-group>
@@ -107,34 +181,30 @@ export default function PersonalDetails() {
                   <div className="col-sm text-center">
                     <label htmlFor="availability">Available to be a :</label>
                     <form-group>
-                      {['checkbox'].map((type) => (
-                        <div key={`inline-${type}`} className="mb-3">
+                        <div className="mb-3">
                           <div className="row">
                             <div className="col-sm">
                               <input
-                                name="mentor"
+                                name="available_to_mentor"
                                 aria-label="mentor"
-                                type={type}
+                                type="checkbox"
                                 defaultChecked={personalDetails.available_to_mentor}
-                                id={`inline-${type}-1`}
-                                disabled
+                                value={"on" ? true : false}
                               />
                               <label htmlFor="mentor">Mentor</label>
                             </div>
                             <div className="col-sm">
                               <input
-                                name="mentee"
+                                name="need_mentoring"
                                 aria-label="mentee"
-                                type={type}
+                                type="checkbox"
                                 defaultChecked={personalDetails.need_mentoring}
-                                id={`inline-${type}-2`}
-                                disabled
+                                value={"on" ? true : false}
                               />
                               <label htmlFor="mentee">Mentee</label>
                             </div>
                           </div>
                         </div>
-                      ))}
                     </form-group>
                   </div>
                 </div>
@@ -145,8 +215,7 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="interests"
-                    placeholder={personalDetails.interests}
-                    disabled
+                    defaultValue={personalDetails.interests}
                   />
                 </p>
               </form-group>
@@ -157,8 +226,7 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="bio"
-                    placeholder={personalDetails.bio}
-                    disabled
+                    defaultValue={personalDetails.bio}
                   />
                 </p>
               </form-group>
@@ -169,8 +237,7 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="location"
-                    placeholder={personalDetails.location}
-                    disabled
+                    defaultValue={personalDetails.location}
                   />
                 </p>
               </form-group>
@@ -181,8 +248,7 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="occupation"
-                    placeholder={personalDetails.occupation}
-                    disabled
+                    defaultValue={personalDetails.occupation}
                   />
                 </p>
               </form-group>
@@ -192,9 +258,8 @@ export default function PersonalDetails() {
                   <label htmlFor="currentOrganization">Current Organization :</label>
                   <input className="field"
                     type="text"
-                    name="currentOrganization"
-                    placeholder={personalDetails.current_organization}
-                    disabled
+                    name="current_organization"
+                    defaultValue={personalDetails.current_organization}
                   />
                 </p>
               </form-group>
@@ -205,8 +270,7 @@ export default function PersonalDetails() {
                   <input className="field"
                     type="text"
                     name="skills"
-                    placeholder={personalDetails.skills}
-                    disabled
+                    defaultValue={personalDetails.skills}
                   />
                 </p>
               </form-group>
@@ -216,9 +280,8 @@ export default function PersonalDetails() {
                   <label htmlFor="resumeUrl">Resume Url :</label>
                   <input className="field"
                     type="text"
-                    name="resumeUrl"
-                    placeholder={personalDetails.resume_url}
-                    disabled
+                    name="resume_url"
+                    defaultValue={personalDetails.resume_url}
                   />
                 </p>
               </form-group>
@@ -228,12 +291,26 @@ export default function PersonalDetails() {
                   <label htmlFor="photoUrl">Photo Url :</label>
                   <input className="field"
                     type="text"
-                    name="photoUrl"
-                    placeholder={personalDetails.photo_url}
-                    disabled
+                    name="photo_url"
+                    defaultValue={personalDetails.photo_url}
                   />
                 </p>
               </form-group>
+              <div><br></br></div>
+              <div>
+                  {responseMessage && <span className="error" name="response" aria-label="response" role="alert">{responseMessage}</span>}
+              </div>
+              <div className="row">
+                <div className="col-sm-6 offset-sm-9">
+                  <button className="btn btn-success"
+                    variant="success"
+                    type="submit"
+                    name="submit"
+                    value="Save"
+                  >Save
+                  </button>
+                </div>
+              </div>
             </form>
           </div>
         </div>

--- a/src/register/Register.jsx
+++ b/src/register/Register.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import "./Register.css";
 import {BASE_API} from "../config";
+import {SERVICE_ERROR} from "../Messages";
 
 
 export default function Register() {
@@ -9,7 +10,7 @@ export default function Register() {
     const [validEmail, setValidEmail] = useState(true);
     const [validPassword, setValidPassword] = useState(true);
     const [responseMessage, setResponseMessage] = useState(null);
-
+    
     const handleSubmit = async e => {
         e.preventDefault();
         let payload = {}
@@ -32,15 +33,15 @@ export default function Register() {
             body: JSON.stringify(payload)
         };
 
-        let data = "";
         fetch(`${BASE_API}/register`, requestRegister)
             .then(async response => {
-
-                data = await response.json();
-                setResponseMessage(data["message"]);
+                let data = await response.json();
+                if (response.status_code === 201)
+                    return setResponseMessage(data.message);
+                setResponseMessage(data.message);
             })
-            .catch(error => {
-                setResponseMessage(data["message"]);
+            .catch(() => {
+                setResponseMessage(SERVICE_ERROR);
             });
     }
 


### PR DESCRIPTION
### Description
Allow user to update their personal details information

Fixes #47 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
- login as a user
- go to `My Space` > `Profile` > `Personal details`
<img width="628" alt="Screen Shot 2020-07-27 at 2 04 38 am" src="https://user-images.githubusercontent.com/29667122/88492407-f2725780-cfed-11ea-8777-2297a8b55f84.png">

<img width="565" alt="Screen Shot 2020-07-27 at 2 04 45 am" src="https://user-images.githubusercontent.com/29667122/88492409-f7370b80-cfed-11ea-90fb-1917c16b3661.png">

- Update details including useername (**NOTE** this is a bug on MS. It's already reported on [issue#596](https://github.com/anitab-org/mentorship-backend/issues/596). User should be allowed to update details without changing username)
- see success message on the bottom of the form
- refresh the page or logout and login with same username. This should fail
<img width="660" alt="Screen Shot 2020-07-27 at 9 42 51 am" src="https://user-images.githubusercontent.com/29667122/88492428-19308e00-cfee-11ea-87ca-3bf05eae36c2.png">

- login with new username and go to Personal Details page. See new details
<img width="1657" alt="Screen Shot 2020-07-27 at 9 43 19 am" src="https://user-images.githubusercontent.com/29667122/88492430-1d5cab80-cfee-11ea-89b9-7d728992a3b0.png">

<img width="980" alt="Screen Shot 2020-07-27 at 9 47 28 am" src="https://user-images.githubusercontent.com/29667122/88492451-3cf3d400-cfee-11ea-94cd-caef258bb3d3.png">

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

