### PR TITLE
Feat: Issue60 view other member details

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Home from "./Home";
 import Members from "./members/Members";
+import MemberProfile from "./members/MemberProfile";
 import Register from "./register/Register";
 import Login from "./login/Login";
 import Portfolio from "./myspace/Portfolio";
@@ -25,6 +26,9 @@ export default function Routes() {
           </Route>
           <ProtectedRoute exact path="/members">
             <Members />
+          </ProtectedRoute>
+          <ProtectedRoute path="/member">
+            <MemberProfile />
           </ProtectedRoute>
           <Route path="/register">
             <Register />

--- a/src/members/MemberProfile.jsx
+++ b/src/members/MemberProfile.jsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+
+export default function MemberProfile() {
+  const { state } = useLocation();
+  const member = state.member;
+  
+  return (
+      <div className="container">
+        <div className="row mb-5">
+          <div className="col-lg-12 text-center">
+            <h1 className="mt-5">{member.name} Personal Details</h1>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-lg-12">
+            <form className="myspace-form mx-auto">
+              <form-group controlId="formUserame">
+                <p className="input-control">
+                  <label htmlFor="username">Username : </label>
+                  {member.username}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formName">
+                <p className="input-control">
+                  <label htmlFor="name">Name : </label>
+                  {member.name}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formIrcId">
+                <p className="input-control">
+                  <label htmlFor="ircId">IRC ID : </label>
+                  {member.slack_username}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formIrcId">
+                <p className="input-control">
+                  <label htmlFor="socialMediaLink">Social Media Links : </label>
+                  {member.social_media_links}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group>
+                <div className="row">
+                  <div className="col-sm text-center">
+                    <label htmlFor="availability">Available to be a : </label>
+                    <form-group>
+                        <div className="mb-3">
+                          <div className="row">
+                            <div className="col-sm">
+                            {member.available_to_mentor &&
+                              <label htmlFor="mentor">Mentor</label>}
+                            </div>
+                            <div className="col-sm">
+                              {member.need_mentoring &&
+                              <label htmlFor="mentee">Mentee</label>}
+                            </div>
+                          </div>
+                        </div>
+                    </form-group>
+                  </div>
+                </div>
+              </form-group>
+              <form-group controlId="formInterests">
+                <p className="input-control">
+                  <label htmlFor="interests">Is available : </label>
+                  {member.is_available? "True" : "False"}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formInterests">
+                <p className="input-control">
+                  <label htmlFor="interests">Interests : </label>
+                  {member.interests}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formBio">
+                <p className="input-control">
+                  <label htmlFor="bio">Bio :</label>
+                  {member.bio}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formLocation">
+                <p className="input-control">
+                  <label htmlFor="location">Location : </label>
+                  {member.location}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formOccupation">
+                <p className="input-control">
+                  <label htmlFor="occupation">Occupation : </label>
+                  {member.occupation}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formCurrentOrganization">
+                <p className="input-control">
+                  <label htmlFor="currentOrganization">Current Organization : </label>
+                  {member.current_organization}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formSkills">
+                <p className="input-control">
+                  <label htmlFor="skills">Skills : </label>
+                  {member.skills}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formResumeUrl">
+                <p className="input-control">
+                  <label htmlFor="resumeUrl">Resume Url : </label>
+                  {member.resume_url}
+                </p>
+              </form-group>
+              <div><br></br></div>
+              <form-group controlId="formPhotoUrl">
+                <p className="input-control">
+                  <label htmlFor="photoUrl">Photo Url : </label>
+                  {member.photo_url}
+                </p>
+              </form-group>
+            </form>
+          </div>
+        </div>
+      </div>
+  )
+}

--- a/src/members/Members.jsx
+++ b/src/members/Members.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext, useEffect } from "react";
 import { Table } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import { AuthContext } from "../AuthContext";
 import { BASE_API } from "../config";
 import { SERVICE_UNAVAILABLE_ERROR } from "../messages";
@@ -31,7 +32,7 @@ export default function Members() {
         setErrorMessage(SERVICE_UNAVAILABLE_ERROR)
       )
 
-  });
+  }, []);
 
   return errorMessage ?
     <div className="container-fluid" id="memberList">
@@ -64,10 +65,13 @@ export default function Members() {
           <tbody>
             {members.map((member) => (
               <tr key={member.id}>
-                <td>{member.name}</td>
+                <td><Link to={{
+                  pathname: `/member/${member.username}`,
+                  state: { member }
+                }}>{member.name}</Link></td>
                 <td>{member.skills}</td>
                 <td>{member.need_mentoring ? "True" : "False"}</td>
-                <td>{member.available_to_mentor? "True" : "False"}</td>
+                <td>{member.available_to_mentor ? "True" : "False"}</td>
                 <td>tba</td>
                 <td>tba</td>
                 <td>{member.location}</td>


### PR DESCRIPTION
### Description
Allow user to view other member's personal details

Fixes #60 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
- Login as a user
- Go to `Members` and select a member from the list of users
- See member details
<img width="607" alt="Screen Shot 2020-08-08 at 12 57 27 am" src="https://user-images.githubusercontent.com/29667122/89659559-63314200-d913-11ea-8a09-f17486b094dd.png">


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes