### PR TITLE
Doc: Add information to README  that Heroku servers are unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ git pull https://github.com/mtreacy002/mentorship-backend.git ms-backend-serve
 
 Follow the rest of the setup instructions (providing the environment credentials) mentioned on the [MS README `Run app` section](https://github.com/anitab-org/mentorship-backend). **Note** Notice that since **BIT** already occupies **port 5000** of your localhost, the **MS** server is set to run on **port 4000** for this BridgeInTech project.
 
-### Option 2: with BIT and MS backend servers run remotely on Heroku
+### Option 2: with BIT and MS backend servers run remotely on Heroku (NOTE: CURRENTLY UNAVAILABLE)
 
 1. Go to `src/config.js` file 
 2. Comment out line 1 that sets `localhost` as the base REST API url for MS server
@@ -42,9 +42,11 @@ Follow the rest of the setup instructions (providing the environment credentials
 <img width="1348" alt="Screen Shot 2020-07-19 at 12 05 25 pm" src="https://user-images.githubusercontent.com/29667122/87865402-3e9f1580-c9b8-11ea-97e1-6dc24fdc970f.png">
 
 **Important**
-Please be aware that there are **drawbacks** if you chose to run the BIT and MS backend servers remotely (**option 2**):
+1. Heroku servers are currently unavailable because the free services we are using are not able to cope with BridgeInTech architecture. Detailed explanation about this can be found [here](https://medium.com/anitab-org-open-source/why-you-cant-use-heroku-free-dynos-in-multiple-servers-dependent-application-fa1cdd9e9e07?source=friends_link&sk=281bb76050f052c03c6772e9be275f67)
+
+2. Even if we found the way to make Heroku servers work, please be aware that there are **drawbacks** if you chose to run the BIT and MS backend servers remotely (**option 2**):
 * There will be a **significant delay** from the time when the request is made on the BIT web GUI to the time the response is received. This is because BIT Heroku makes calls to MS-for-BIT Heroku backend server for MS related functionalities. Both of these Heroku servers are running on [free `dynos`](https://www.heroku.com/dynos) that have limited capacity. When you run both BIT and MS-for-BIT servers locally, you will not have this time lag issue.
-* The BIT Heroku baackend server will only carries the latest code that have been approved and merged to the develop branch. This means, if you are working on a PR or testing an open PR, this **Option 2** (running remote BIT Heroku server) **MUST NOT BE USED**.     
+* The BIT Heroku backend server will only carry the latest code that have been approved and merged to the develop branch. This means, if you are working on a PR or testing an open PR, this **Option 2** (running remote BIT Heroku server) **MUST NOT BE USED**.     
 
 ## Run the app
 


### PR DESCRIPTION
### Description
Add information that Heroku serverrs are currently unavailable due to [free dynos limitation](https://medium.com/anitab-org-open-source/why-you-cant-use-heroku-free-dynos-in-multiple-servers-dependent-application-fa1cdd9e9e07?source=friends_link&sk=281bb76050f052c03c6772e9be275f67)

Fixes #113 

### Type of Change:
- Documentation

**Code/Quality Assurance Only**
NA

### How Has This Been Tested?

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes