### PR TITLE
Fix: Stop useEffect from sending multiple requests to the backend

### DIFF
--- a/src/members/Members.jsx
+++ b/src/members/Members.jsx
@@ -11,16 +11,17 @@ export default function Members() {
   const [members, setMembers] = useState([]);
   const { access_token } = useContext(AuthContext);
 
-  const requestMembersList = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
 
   useEffect(() => {
+    const requestMembersList = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/users`, requestMembersList)
       .then(async response => {
         const data = await response.json();
@@ -33,7 +34,7 @@ export default function Members() {
         setErrorMessage(SERVICE_UNAVAILABLE_ERROR)
       )
 
-  }, [requestMembersList]);
+  }, [access_token]);
 
   return errorMessage ?
     <div className="container-fluid">

--- a/src/myorganization/EditOrganization.jsx
+++ b/src/myorganization/EditOrganization.jsx
@@ -14,16 +14,17 @@ export default function EditOrganization() {
   const {access_token} = useContext(AuthContext);
   const [isValidPhone, setIsValidPhone] = useState(true);
 
-  const requestOrganization = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
 
   useEffect(() => {
+    const requestOrganization = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/organization`, requestOrganization)
       .then(async response => {
         const data = await response.json();
@@ -35,7 +36,7 @@ export default function EditOrganization() {
       .catch(() =>
         setResponseMessage(SERVICE_UNAVAILABLE_ERROR)
       )
-  }, [requestOrganization]);
+  }, [access_token]);
 
   const handleSubmit = async e => {
     e.preventDefault();

--- a/src/myorganization/EditPrograms.jsx
+++ b/src/myorganization/EditPrograms.jsx
@@ -14,16 +14,17 @@ export default function EditPrograms() {
   const [programs, setPrograms] = useState(null);
   const { access_token } = useContext(AuthContext);
 
-  const requestOrganization = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
 
   useEffect(() => {
+    const requestOrganization = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/organizations/${organization.id}/programs`, requestOrganization)
       .then(async response => {
         const data = await response.json();
@@ -35,7 +36,7 @@ export default function EditPrograms() {
       .catch(() =>
         setResponseMessage(SERVICE_UNAVAILABLE_ERROR)
       )
-  }, [requestOrganization, organization.id]);
+  }, [access_token, organization.id]);
 
   return (
     <div className="container-fluid">

--- a/src/myspace/AdditionalInfo.jsx
+++ b/src/myspace/AdditionalInfo.jsx
@@ -13,16 +13,17 @@ export default function AdditionalInfo() {
   const [isValidPhone, setIsValidPhone] = useState(true);
   const [isValidMobile, setIsValidMobile] = useState(true);
 
-  const requestAdditionalInfo = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
 
   useEffect(() => {
+    const requestAdditionalInfo = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/user/additional_info`, requestAdditionalInfo)
       .then(async response => {
         const data = await response.json();
@@ -34,7 +35,7 @@ export default function AdditionalInfo() {
       .catch(() =>
         setResponseMessage(SERVICE_UNAVAILABLE_ERROR)
       )
-  }, [requestAdditionalInfo]);
+  }, [access_token]);
 
   const handleSubmit = async e => {
     e.preventDefault();

--- a/src/myspace/PersonalBackground.jsx
+++ b/src/myspace/PersonalBackground.jsx
@@ -21,16 +21,16 @@ export default function PersonalBackground() {
   const [personalBackground, setPersonalBackground] = useState({});
   const { access_token, user } = useContext(AuthContext);
 
-  const requestPersonalBackground = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
-
   useEffect(() => {
+    const requestPersonalBackground = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/user/personal_background`, requestPersonalBackground)
     .then(async response => {
       const data = await response.json();
@@ -42,7 +42,7 @@ export default function PersonalBackground() {
       setResponseMessage(SERVICE_UNAVAILABLE_ERROR)
     )
 
-  }, [requestPersonalBackground]);
+  }, [access_token]);
 
   const handleSubmit = async e => {
     e.preventDefault();

--- a/src/myspace/PersonalDetails.jsx
+++ b/src/myspace/PersonalDetails.jsx
@@ -14,16 +14,17 @@ export default function PersonalDetails() {
   const [isValidUsername, setIsValidUsername] = useState(true);
 
 
-  const requestPersonalDetails = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
 
   useEffect(() => {
+    const requestPersonalDetails = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/user/personal_details`, requestPersonalDetails)
       .then(async response => {
         const data = await response.json();
@@ -34,7 +35,7 @@ export default function PersonalDetails() {
       .catch(() =>
         setErrorMessage(SERVICE_UNAVAILABLE_ERROR)
       )
-  }, [requestPersonalDetails]);
+  }, [access_token]);
 
   const handleSubmit = async e => {
     e.preventDefault();

--- a/src/organizations/Organizations.jsx
+++ b/src/organizations/Organizations.jsx
@@ -11,16 +11,17 @@ export default function Organizations() {
   const [organizations, setOrganizations] = useState([]);
   const { access_token } = useContext(AuthContext);
 
-  const requestOrganizationsList = {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${access_token}`,
-      "Accept": "application/json",
-      "Content-Type": "application/json",
-    },
-  };
 
   useEffect(() => {
+    const requestOrganizationsList = {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+
     fetch(`${BASE_API}/organizations`, requestOrganizationsList)
       .then(async response => {
         const data = await response.json();
@@ -33,7 +34,7 @@ export default function Organizations() {
         setErrorMessage(SERVICE_UNAVAILABLE_ERROR)
       )
 
-  }, [requestOrganizationsList]);
+  }, [access_token]);
 
   return errorMessage ?
     <div className="container-fluid">

--- a/src/organizations/Programs.jsx
+++ b/src/organizations/Programs.jsx
@@ -13,16 +13,17 @@ export default function Programs() {
     const [programs, setPrograms] = useState(null);
     const { access_token } = useContext(AuthContext);
 
-    const requestOrganization = {
-        method: "GET",
-        headers: {
-          "Authorization": `Bearer ${access_token}`,
-          "Accept": "application/json",
-          "Content-Type": "application/json",
-        },
-      };
 
-      useEffect(() => {
+    useEffect(() => {
+        const requestOrganization = {
+            method: "GET",
+            headers: {
+              "Authorization": `Bearer ${access_token}`,
+              "Accept": "application/json",
+              "Content-Type": "application/json",
+            },
+        };
+
           fetch(`${BASE_API}/organizations/${organization.id}/programs`, requestOrganization)
             .then(async response => {
               const data = await response.json();
@@ -33,7 +34,7 @@ export default function Programs() {
             .catch(() =>
               setResponseMessage(SERVICE_UNAVAILABLE_ERROR)
             )
-          }, [requestOrganization, organization.id]);
+          }, [access_token, organization.id]);
 
           return programs ?
           <div className="container-fluid">


### PR DESCRIPTION
### Description
Modified the conflicting files by moving the additional info required by the fetch method inside the useEffect hook. This will prevent the respective components from rendering again, thus preventing continuous requests to the backend.

Fixes #158 

### Type of Change:

- Code
- Quality Assurance


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested through the network tab of developer tools. The network requests are made to the backend to fetch only resources the current page needs, as shown in the below video.


https://user-images.githubusercontent.com/17108695/106255627-4c273900-6240-11eb-82ed-e1f380fe0e9d.mp4




### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes