### PR TITLE
Fix: Removed warning generated due to invalid href attribute.

### DIFF
--- a/src/register/Register.jsx
+++ b/src/register/Register.jsx
@@ -237,7 +237,7 @@ export default function Register() {
                                 <div className="col-sm-10">
                                     <label>
                                         By checking this box, I affirm that I have read and accept
-                                        to be bound by the AnitaB.org <a href="#" onClick={()=>{setShowTermsModal(true)}}>Code of Conduct, Terms, and
+                                        to be bound by the AnitaB.org <a href="#modal" onClick={()=>{setShowTermsModal(true)}}>Code of Conduct, Terms, and
                                         Privacy Policy</a>. Further I consent to the use of my
                                         information for the stated purpose.
                                     </label>


### PR DESCRIPTION
### Description

Removed the warning that was being generated due to invalid href attribute.

Fixes #192 

### Type of Change:
<!--**Delete irrelevant options.**-->

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
No warnings are being generated now.
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/53488062/110909057-a2a28f80-8335-11eb-8f40-fe48558544a2.gif)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings