### PR TITLE
Fix: 404 Page Overlapping

### DIFF
--- a/src/errorPage/ErrorPage.css
+++ b/src/errorPage/ErrorPage.css
@@ -4,12 +4,8 @@
  }
  
  .errorPage {
-     position: absolute;
-     top: 15%;
-     left: 17%;
-     right: 17%;
+     padding: 1rem;
      color: whitesmoke;
-     bottom: 20%;
      display: flex;
      align-items: center;
      justify-content: center;

--- a/src/errorPage/ErrorPage.js
+++ b/src/errorPage/ErrorPage.js
@@ -4,16 +4,14 @@ import { Link } from 'react-router-dom';
 
 export default function ErrorPage() {
     return (
-        
-                       <div className="errorPage">
-             <div className="errorPage_content">
+            <div className="errorPage">
+                <div className="errorPage_content">
                     <h1>404</h1>
                     <h4>Oops! Page Not Found</h4>
                     <p>Sorry, the page you were looking for doesn't exist. If you think something is wrong, try again.</p>
                     <button className="button"><Link to="/">Go to Home </Link></button>
                 </div>
             </div>
-       
     )
 }
 


### PR DESCRIPTION
### Description

Solved the overlapping of Header and 404 Page.

Fixes #187

### Type of Change:
- Code
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Before:
![anitab404OverlappingBefore_187](https://user-images.githubusercontent.com/43892590/111052382-3f714400-8480-11eb-868f-61602a5e90dc.gif)

Now:
![anitab404Overlapping_187](https://user-images.githubusercontent.com/43892590/111052327-d5589f00-847f-11eb-9b1e-a0a24b700fd0.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes