### PR TITLE
docs: add link to Bridge In Tech zulip stream in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-* You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). Each active repo has its own stream to direct questions to (for example #powerup or #portal). You can find the Bridge in Tech stream [here](https://anitab-org.zulipchat.com/#narrow/stream/237630-bridge-in-tech).
+* You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). Each active repo has its own stream to direct questions to (for example #powerup or #portal). Bridge in Tech stream is [#bridge-in-tech](https://anitab-org.zulipchat.com/#narrow/stream/237630-bridge-in-tech).
 * Remember that this is an inclusive community, committed to creating a safe, positive environment.  See the full [Code of Conduct](http://www.systers.io/code-of-conduct.html).
 * Follow our [Commit Message Style Guide](https://github.com/anitab-org/bridge-in-tech-web/wiki/Commit-Message-Style-Guide) when you commit your changes.
 * Please consider raising an issue before submitting a pull request (PR) to solve a problem that is not present in our [issue tracker](https://github.com/anitab-org/bridge-in-tech-web/issues). This allows maintainers to first validate the issue you are trying to solve and also reference the PR to a specific issue.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-* You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/).  Each active repo has its own stream to direct questions to (for example #powerup or #portal). Bridge in Tech stream is _blank_.
+* You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). Each active repo has its own stream to direct questions to (for example #powerup or #portal). You can find the Bridge in Tech stream [here](https://anitab-org.zulipchat.com/#narrow/stream/237630-bridge-in-tech).
 * Remember that this is an inclusive community, committed to creating a safe, positive environment.  See the full [Code of Conduct](http://www.systers.io/code-of-conduct.html).
 * Follow our [Commit Message Style Guide](https://github.com/anitab-org/bridge-in-tech-web/wiki/Commit-Message-Style-Guide) when you commit your changes.
 * Please consider raising an issue before submitting a pull request (PR) to solve a problem that is not present in our [issue tracker](https://github.com/anitab-org/bridge-in-tech-web/issues). This allows maintainers to first validate the issue you are trying to solve and also reference the PR to a specific issue.


### PR DESCRIPTION
### Description

<!--A link to the Bridge In Tech stream on the zulip chat has been mentioned in the documentation which was missing earlier.-->

Fixes #204

### Type of Change:

- Documentation

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation