### PR TITLE
Bug: Members list not scrollable on smaller screen sizes

### DIFF
--- a/src/members/Member.css
+++ b/src/members/Member.css
@@ -1,50 +1,57 @@
 .container-members {
-    background: #f7f9fa;
-    height: auto;
-    width: 90vw;
-    margin: 5em auto;
-    -webkit-box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.4);
-    -moz-box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.4);
-    box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.4);
-  }
-  
+  background: #f7f9fa;
+  height: auto;
+  width: 90vw;
+  margin: 5em auto;
+  -webkit-box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.4);
+  -moz-box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.4);
+  box-shadow: 5px 5px 5px 0px rgba(0, 0, 0, 0.4);
+}
+
 label {
-    color: #24b9b6;
-    font-size: 1.2em;
-    font-weight: 400;
+  color: #24b9b6;
+  font-size: 1.2em;
+  font-weight: 400;
+}
+
+h1 {
+  color: #24b9b6;
+  padding-top: 0.5em;
+}
+
+.error {
+  color: red;
+}
+.error-message {
+  color: #ff6565;
+  padding: 0.5em 0.2em;
+  height: 1em;
+  position: absolute;
+  font-size: 0.8em;
+}
+
+.field {
+  border: 1px solid #1c6ea4;
+  width: 100%;
+  height: 2em;
+}
+
+.button-group {
+  width: 100%;
+}
+
+.membersList {
+  width: 85vw;
+  text-align: center;
+  padding: 2em;
+  margin: 3em 3em;
+  padding: 2em;
+}
+
+@media only screen and (max-width: 644px) {
+  .container-members {
+    overflow: hidden;
+    overflow-x: scroll;
   }
-  
-  h1 {
-    color: #24b9b6;
-    padding-top: 0.5em;
-  }
-  
-  .error {
-    color: red;
-  }
-  .error-message {
-    color: #ff6565;
-    padding: 0.5em 0.2em;
-    height: 1em;
-    position: absolute;
-    font-size: 0.8em;
-  }
-  
-  .field {
-    border: 1px solid #1c6ea4;
-    width: 100%;
-    height: 2em;
-  }
-  
-  .button-group {
-    width: 100%;
-  }
-  
-  .membersList {
-    width: 85vw;
-    text-align: center;
-    padding: 2em;
-    margin: 3em 3em;
-    padding: 2em;
-  }
-  
+}
+

--- a/src/members/Member.css
+++ b/src/members/Member.css
@@ -50,7 +50,7 @@ h1 {
 
 @media only screen and (max-width: 644px) {
   .container-members {
-    overflow: hidden;
+    overflow: auto;
     overflow-x: scroll;
   }
 }

--- a/src/members/Member.css
+++ b/src/members/Member.css
@@ -54,4 +54,3 @@ h1 {
     overflow-x: scroll;
   }
 }
-


### PR DESCRIPTION
### Description

adding media query in Member.css as ;-

  @media only screen and (max-width: 644px) {
  .container-members {
    overflow: hidden;
    overflow-x: scroll;
  }
}

After Changes : -

![bug](https://user-images.githubusercontent.com/54985099/113509221-09e8e380-9572-11eb-9478-916f89e183c3.gif)


Fixes #199 

### Type of Change:
<!--**Delete irrelevant options.**-->

- Code


**Code/Quality Assurance Only**

- Bug fix (non-breaking change which fixes an issue)


### Checklist:
<!--**Delete irrelevant options.**-->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes