### PR TITLE
FIX: validation alert not shown when user enters spaces as input in name and password fields(#202)

### DIFF
--- a/src/register/Register.jsx
+++ b/src/register/Register.jsx
@@ -97,7 +97,7 @@ export default function Register() {
                                     placeholder="Full Name"
                                     minLength={2}
                                     maxLength={30}
-                                    pattern="^[a-zA-Z\s\-]+$"
+                                    pattern="^[^\s].[a-zA-Z\s\-]+$"
                                     onChange={validateName}
                                     required
                                 />
@@ -156,6 +156,7 @@ export default function Register() {
                                     placeholder="Password"
                                     minLength={8}
                                     maxLength={64}
+                                    pattern="^[^\s].[a-zA-Z0-9/_]+$"
                                     onChange={validatePassword}
                                     required
                                 />
@@ -176,6 +177,7 @@ export default function Register() {
                                     placeholder="Confirm Password"
                                     minLength={8}
                                     maxLength={64}
+                                    pattern="^[^\s].[a-zA-Z0-9/_]+$"
                                     onChange={validateConfirmPassword}
                                     required
                                 />


### PR DESCRIPTION
### Description
Validated name, password, confirm password field in register page for spaces as input using regex patterns.

Fixes #202 

### Type of Change:
<!--**Delete irrelevant options.**-->

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Manually

### Screenshot
![](https://github.com/sachinsom93/temp/blob/master/bridge.jpg?raw=true)


### Checklist:
<!--**Delete irrelevant options.**-->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules