### PR TITLE
test: logged in user gets redirected to Home with username on main Navigation bar

### DIFF
--- a/src/tests/Login.test.jsx
+++ b/src/tests/Login.test.jsx
@@ -147,6 +147,8 @@ it('redirects to Home if user is logged in', () => {
     const history = createBrowserHistory();
     history.replace = jest.fn();
 
+    const pathToHome = '/';
+
     render(
         <AuthContext.Provider value={{ isAuth: true }}>
             <Router history={history}>
@@ -158,6 +160,6 @@ it('redirects to Home if user is logged in', () => {
     expect(screen.queryByRole('button', { name: "Login" })).not.toBeInTheDocument();
 
     expect(history.replace).toHaveBeenCalledWith(expect.objectContaining({
-        pathname: '/'
+        pathname: pathToHome,
     })); 
 });

--- a/src/tests/Login.test.jsx
+++ b/src/tests/Login.test.jsx
@@ -6,9 +6,9 @@ import '@testing-library/jest-dom';
 import Login from "../login/Login";
 import { act } from 'react-dom/test-utils';
 import { BASE_API } from "../config";
-import { Router } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import { AuthContext } from '../AuthContext';
+import { BrowserRouter as Router, Router as Redirect   } from 'react-router-dom';
 
 const server = setupServer(
     rest.post(`${BASE_API}/login`, (req, res, ctx) => {
@@ -30,7 +30,7 @@ afterAll(() => server.close())
 
 
 it('allows the user to login successfully', async () => {
-    render(<Login />)
+    render(<Router><Login /></Router>)
 
     fireEvent.change(screen.getByPlaceholderText('Username or Email'), {
         target: { value: 'MyUsername' },
@@ -60,7 +60,7 @@ it('handles wrong credentials', async () => {
       }),
     )
    
-    render(<Login />)
+    render(<Router><Login /></Router>)
    
     fireEvent.change(screen.getByPlaceholderText('Username or Email'), {
         target: { value: 'MyUsername' },
@@ -91,7 +91,7 @@ it('handles wrong credentials', async () => {
       }),
     )
    
-    render(<Login />)
+    render(<Router><Login /></Router>)
    
     fireEvent.change(screen.getByPlaceholderText('Username or Email'), {
         target: { value: 'MyUsername' },
@@ -112,7 +112,7 @@ it('handles wrong credentials', async () => {
 
 it('checks if the fields are empty', async () => {
 
-    render(<Login />)
+    render(<Router><Login /></Router>)
 
     fireEvent.change(screen.getByLabelText("Username or Email:", {selector: "input"}), {target: { value: "" }})
     
@@ -131,7 +131,7 @@ it('checks if the fields are empty', async () => {
 
 
 it('handles password toggle', () => {
-    render(<Login />)
+    render(<Router><Login /></Router>)
 
     expect(screen.getByPlaceholderText('Password').type).toEqual("password")
 
@@ -151,9 +151,9 @@ it('redirects to Home if user is logged in', () => {
 
     render(
         <AuthContext.Provider value={{ isAuth: true }}>
-            <Router history={history}>
+            <Redirect history={history}>
                 <Login />
-            </Router>
+            </Redirect>
         </AuthContext.Provider>
     );
 

--- a/src/tests/Navigation.test.jsx
+++ b/src/tests/Navigation.test.jsx
@@ -1,11 +1,9 @@
-import { render } from '@testing-library/react';
 import React from 'react';
-import { Router } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
 import { AuthContext } from '../AuthContext';
 import Navigation from '../Navigation';
-import { createMemoryHistory } from 'history';
 
-const history = createMemoryHistory();
 const mockAuthContext = { isAuth: true, user: "AnitaB" };
 
 describe('Navigation', () => {
@@ -14,11 +12,12 @@ describe('Navigation', () => {
         
         const { getByText } = render(
             <AuthContext.Provider value={mockAuthContext}>
-               <Router history={history}>
+               <BrowserRouter>
                     <Navigation />
-               </Router>
+               </BrowserRouter>
             </AuthContext.Provider>
         );
+        
         expect(getByText(`Welcome back, ${mockAuthContext.user}!`)).toBeInTheDocument();
     });
 });

--- a/src/tests/Navigation.test.jsx
+++ b/src/tests/Navigation.test.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { AuthContext } from '../AuthContext';
+import Navigation from '../Navigation';
+import { createMemoryHistory } from 'history';
+
+const history = createMemoryHistory();
+const mockAuthContext = { isAuth: true, user: "AnitaB" };
+
+describe('Navigation', () => {
+
+    it('should display username when user is logged in', () => {
+        
+        const { getByText } = render(
+            <AuthContext.Provider value={mockAuthContext}>
+               <Router history={history}>
+                    <Navigation />
+               </Router>
+            </AuthContext.Provider>
+        );
+        expect(getByText(`Welcome back, ${mockAuthContext.user}!`)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
### Description

- Fixes #33 

- Adds a test to check that the `Login` component will redirect to `Home` after a successful login (or when directly accessing the /login route). 

- The issue also requires a test to check that the logged in user's username is displayed on the `Navigation` bar after being redirected to `Home`.  As this is really checking `Navigation` component functionality, not `Login`, I have added a separate test file for `Navigation`

- The `Login` test requires an import of the `history` dependency

### Type of Change:

- Quality Assurance

### How Has This Been Tested?

- `npm run test`

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules